### PR TITLE
Handle manifest upload internal server error

### DIFF
--- a/src/main/java/org/example/stage_back/xml_parser/DetailManifest.java
+++ b/src/main/java/org/example/stage_back/xml_parser/DetailManifest.java
@@ -6,6 +6,7 @@ import java.util.List;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class DetailManifest {
 
+    @XmlElementWrapper(name = "Informations")
     @XmlElement(name = "InformationMarchandise")
     private List<InformationMarchandise> informations;
 

--- a/src/main/java/org/example/stage_back/xml_parser/HeaderXml.java
+++ b/src/main/java/org/example/stage_back/xml_parser/HeaderXml.java
@@ -56,6 +56,10 @@ public class HeaderXml {
     public void setTrafic(String trafic) { this.Trafic = trafic; }
 
     public Integer getNavireID() {
-        return Integer.parseInt(NavireID);
+        try {
+            return (NavireID == null || NavireID.isBlank()) ? null : Integer.parseInt(NavireID.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/src/main/java/org/example/stage_back/xml_parser/IfcSumXml.java
+++ b/src/main/java/org/example/stage_back/xml_parser/IfcSumXml.java
@@ -3,11 +3,11 @@ package org.example.stage_back.xml_parser;
 import jakarta.xml.bind.annotation.*;
 import java.util.List;
 
-@XmlRootElement(name = "IFCSUM_XML")
+@XmlRootElement(name = "IFCSUM")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class IfcSumXml {
 
-    @XmlElement(name = "header")
+    @XmlElement(name = "Header")
     private HeaderXml header;
 
     @XmlElement(name = "DetailManifeste")


### PR DESCRIPTION
Update XML parsing for manifest upload and add null-safe handling for NavireID to resolve 500 errors.

The 500 error occurred because the backend's JAXB XML parsing model did not precisely match the incoming manifest XML structure (incorrect root and header element names, missing wrapper for `Informations`). Additionally, the `NavireID` field could cause a `NumberFormatException` if it was null, blank, or non-numeric. These changes align the parsing logic and prevent runtime errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-4831ee39-18e7-4dd8-96c6-fcf949f02158">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4831ee39-18e7-4dd8-96c6-fcf949f02158">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

